### PR TITLE
added @tinyhttp/swagger

### DIFF
--- a/packages/swagger/package.json
+++ b/packages/swagger/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "swagger",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json",
+    "./": "./"
+  },
+  "devDependencies": {
+    "@types/swagger-ui-express": "^4.1.2",
+    "ts-node": "^10.0.0",
+    "typescript": "^4.3.2"
+  },
+  "dependencies": {
+    "@tinyhttp/app": "workspace:*",
+    "@tinyhttp/router": "workspace:*",
+    "json-format": "^1.0.1",
+    "swagger-ui-express": "^4.1.6"
+  }
+}

--- a/packages/swagger/src/index.ts
+++ b/packages/swagger/src/index.ts
@@ -1,0 +1,51 @@
+import { createBodySub, createParameterSubs, body, parameters } from './schema'
+import { App, Request, Response, NextFunction, Middleware } from '@tinyhttp/app'
+import { Handler, AsyncHandler } from '@tinyhttp/router'
+
+type SwaggerHandler = (Handler | AsyncHandler) & { schema: any }
+
+export function addToDocs(schema: parameters & { body?: body }) {
+  const mw = async (_req: Request, _res: Response, next: NextFunction) => {
+    next()
+  }
+  mw.schema = schema
+  return mw
+}
+
+export function generateDocs(app: App) {
+  const routes = app.middleware
+    .filter(mw => mw.type == 'route' && (mw.handler as SwaggerHandler).schema)
+    .map(route => {
+      return {
+        path: ((route as Middleware).path as string).replace(
+          /:(?<param>[A-Za-z0-9_]+)/g,
+          '{$<param>}'
+        ),
+        schema: (route.handler as SwaggerHandler).schema,
+        method: route.method,
+      }
+    })
+
+  const uniquePathsSet = new Set(routes.map(r => r.path))
+  const uniquePaths = Array.from(uniquePathsSet.keys()) as string[]
+  const docs = uniquePaths.map(path => {
+    const merged = routes
+      .filter(route => route.path == path)
+      .map(route => {
+        const tmp: { [_: string]: any } = {}
+        tmp[path] = {}
+        tmp[path][(route.method as string).toLowerCase()] = {
+          parameters: createParameterSubs({
+            headers: route.schema.headers,
+            params: route.schema.params,
+            query: route.schema.query,
+          }),
+          requestBody: createBodySub(route.schema.body),
+        }
+        return tmp
+      })
+    return merged
+  })
+
+  return docs
+}

--- a/packages/swagger/src/schema.ts
+++ b/packages/swagger/src/schema.ts
@@ -1,0 +1,124 @@
+export type parameters = { headers?: schema; params?: schema; query?: schema }
+export type origin = 'header' | 'query' | 'path'
+export type schema = {
+  [_: string]:
+    | 'number'
+    | 'string'
+    | { type: 'number' | 'string'; optional?: boolean; [_: string]: any }
+}
+export type body = {
+  [_: string]:
+    | 'boolean'
+    | 'number'
+    | 'string'
+    | {
+        type: 'boolean' | 'number' | 'string'
+        optional?: boolean
+        [_: string]: any
+      }
+    | {
+        type: 'array'
+        items: 'boolean' | 'string' | 'number'
+        optional?: boolean
+        [_: string]: any
+      }
+}
+
+export type contentType =
+  | 'application/x-www-form-urlencoded'
+  | 'multipart/form-data'
+  | 'application/json'
+
+export function createBodySub(
+  schema: body,
+  contentType: contentType = 'application/json'
+) {
+  if (!schema || Object.keys(schema).length == 0) return {}
+
+  const content: { [_: string]: { schema: any } } = {}
+  content[contentType] = { schema: bodyToOpenAPI(schema) }
+  return {
+    required: true,
+    content,
+  }
+}
+
+export function createParameterSubs(parameters: parameters) {
+  const query = parameters.query
+  const params = parameters.params
+  const headers = parameters.headers
+
+  let querySubs = []
+  let paramSubs = []
+  let headerSubs = []
+
+  if (query) querySubs = schemaToOpenAPI(query, 'query')
+  if (params) paramSubs = schemaToOpenAPI(params, 'path')
+  if (headers) headerSubs = schemaToOpenAPI(headers, 'header')
+
+  return [...querySubs, ...paramSubs, ...headerSubs]
+}
+
+function bodyToOpenAPI(schema: body) {
+  const names = Object.keys(schema)
+
+  const required = names.filter(n => {
+    if (typeof schema[n] == 'string') {
+      return true
+    }
+
+    return !!!(
+      schema[n] as { optional?: boolean; type: 'string' | 'number' | 'boolean' }
+    )['optional']
+  })
+
+  const properties = names.map(n => {
+    if (typeof schema[n] == 'string') {
+      const tmp: { [_: string]: { type: string } } = {}
+      tmp[n] = { type: schema[n] as string }
+      return tmp
+    }
+
+    if ((schema[n] as { type: string; [_: string]: any })['type'] == 'array') {
+      const tmp: { [_: string]: { type: string; items: { type: string } } } = {}
+      tmp[n] = {
+        type: 'array',
+        items: { type: (schema[n] as { items: string })['items'] },
+      }
+      return tmp
+    }
+
+    const tmp: { [_: string]: { type: string } } = {}
+    tmp[n] = { type: (schema[n] as { type: string })['type'] }
+    return tmp
+  })
+
+  return { type: 'object', required, properties }
+}
+
+function schemaToOpenAPI(schema: schema, origin: origin): any[] {
+  const names = Object.keys(schema)
+  const subs = names.map(n => {
+    if (typeof schema[n] == 'string') {
+      return {
+        in: origin,
+        required: true,
+        name: n,
+        schema: { type: schema[n] },
+      }
+    }
+
+    const details = schema[n] as {
+      optional?: boolean
+      type: 'string' | 'number' | 'boolean'
+    }
+
+    return {
+      in: origin,
+      required: !!!details.optional,
+      name: n,
+      schema: { type: details.type },
+    }
+  })
+  return subs
+}

--- a/packages/swagger/tsconfig.json
+++ b/packages/swagger/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "src",
+        "outDir": "dist",
+        "esModuleInterop": true
+    }
+}


### PR DESCRIPTION
Hi
a while back I wanted to use tinyhttp in a project at my work, but because I needed swagger documentation and I'm too lazy to actually write it myself, I used fastify instead which does have automatic swagger doc generation.
But because I liked tinyhttp and I also wanted to start contributing to open source, I decided to do it myself. So here we are.
The way it works, is that you give each route that you want to appear in your documentation, a middleware and pass validation data to it in the style of `fastest-validator`(that's what you decided to use for validation, right?). Currently it ignores anything other than `type`, `optional` and `items` in case `type` is `array`.
The object can have `headers`, `params`, `query` and `body`. Here is an example:

```javascript
import { App } from '@tinyhttp/app'
import { addToDocs, generateDocs } from '@tinyhttp/swagger'

const schema = {
  id: { type: 'number', positive: true, integer: true },
  name: { type: 'string', min: 3, max: 255 },
  status: 'boolean' 
}

const app = new App()

app
  .post('/', 
    addToDocs({ headers: {authorization: 'string'}, params: { docId: 'number' }, body: schema }),
    (req, res) => {
      res.status(200).send('done')
  })


writeFileSync('docs.json', JSON.stringify(generateDocs(app)), { encoding: 'utf-8' })
app.listen(3000)
```

Currently it only works if you call `generateDocs` after all the routes are registered. I also had problem using `swagger-ui-express` to serve it. But I'm not sure I have more time  to figure it out. So currently you have to serve the doc manually.
I know the api is a bit awkward but I'm just trying to get the ball rolling so maybe others can help me make it better.
Hope this will be helpful.