### PR TITLE
Fix: Issue #330 empty query params

### DIFF
--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -22,11 +22,11 @@ export type URLParams = {
   [key: string]: string
 }
 
-export const getPathname = (url: string): string => url.slice(0, getQueryIndex(url))
-
-export const getQueryParams = (url = '/'): ParsedUrlQuery => parse(url.slice(getQueryIndex(url) + 1))
-
 const getQueryIndex = (url: string): number => {
   const index = url.indexOf('?')
   return index === -1 ? url.length : index
 }
+
+export const getPathname = (url: string): string => url.slice(0, getQueryIndex(url))
+
+export const getQueryParams = (url = '/'): ParsedUrlQuery => parse(url.slice(getQueryIndex(url) + 1))

--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -22,10 +22,11 @@ export type URLParams = {
   [key: string]: string
 }
 
-export const getPathname = (u: string): string => {
-  const end = u.indexOf('?')
+export const getPathname = (url: string): string => url.slice(0, getQueryIndex(url));
 
-  return u.slice(0, end === -1 ? u.length : end)
+export const getQueryParams = (url = '/'): ParsedUrlQuery => parse(url.slice(getQueryIndex(url) + 1));
+
+const getQueryIndex = (url: string): number => {
+  const index = url.indexOf('?');
+  return index === -1 ? url.length : index;
 }
-
-export const getQueryParams = (url = '/'): ParsedUrlQuery => parse(url.slice(url.indexOf('?') + 1))

--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -22,11 +22,11 @@ export type URLParams = {
   [key: string]: string
 }
 
-export const getPathname = (url: string): string => url.slice(0, getQueryIndex(url));
+export const getPathname = (url: string): string => url.slice(0, getQueryIndex(url))
 
-export const getQueryParams = (url = '/'): ParsedUrlQuery => parse(url.slice(getQueryIndex(url) + 1));
+export const getQueryParams = (url = '/'): ParsedUrlQuery => parse(url.slice(getQueryIndex(url) + 1))
 
 const getQueryIndex = (url: string): number => {
-  const index = url.indexOf('?');
-  return index === -1 ? url.length : index;
+  const index = url.indexOf('?')
+  return index === -1 ? url.length : index
 }

--- a/tests/modules/url.test.ts
+++ b/tests/modules/url.test.ts
@@ -8,6 +8,11 @@ describe('getQueryParams(url)', () => {
 
     expect(getQueryParams(str)).toEqual({ world: '42' })
   })
+  it('parses the url and return empty object if no query params found', () => {
+    const str = '/hello'
+
+    expect(getQueryParams(str)).toEqual({})
+  })
 })
 
 describe('getURLParams(reqUrl, url)', () => {


### PR DESCRIPTION
closes #330 
returns empty object ('{}') if no query params found

