### PR TITLE
fix: omit optional URL params when not supplied in request

### DIFF
--- a/packages/url/src/index.ts
+++ b/packages/url/src/index.ts
@@ -12,7 +12,9 @@ export const getURLParams = ({ pattern, keys }: Regex, reqUrl = '/'): URLParams 
 
   if (matches && typeof keys !== 'boolean')
     for (let i = 0; i < keys.length; i++) {
-      params[keys[i]] = decodeURIComponent(matches[i + 1])
+      if (matches[i + 1]) {
+        params[keys[i]] = decodeURIComponent(matches[i + 1])
+      }
     }
 
   return params

--- a/tests/modules/url.test.ts
+++ b/tests/modules/url.test.ts
@@ -23,6 +23,13 @@ describe('getURLParams(reqUrl, url)', () => {
 
     expect(getURLParams(regex, reqUrl)).toStrictEqual({})
   })
+  it('omits optional param when not supplied', () => {
+    const reqUrl = '/foo/qaz'
+
+    const regex = rg('/foo/:bar/:baz?')
+
+    expect(getURLParams(regex, reqUrl)).toStrictEqual({ bar: 'qaz' })
+  })
   it('parses URL params and returns an object with matches', () => {
     const reqUrl = '/hello/world'
 


### PR DESCRIPTION
When optional URL params (i.e. `/foo/:bar?`) are not supplied in the request, the corresponding key should also not be present in the `getURLParams` result.

Closes #331 