### PR TITLE
docs: remove CommonJS references

### DIFF
--- a/packages/accepts/README.md
+++ b/packages/accepts/README.md
@@ -1,6 +1,6 @@
 # @tinyhttp/accepts
 
-> [`accepts`](https://github.com/jshttp/accepts) rewrite in TypeScript with ESM and CommonJS targets.
+> [`accepts`](https://github.com/jshttp/accepts) rewrite in TypeScript.
 
 Higher level content negotiation based on [negotiator](https://www.npmjs.com/package/negotiator).
 Extracted from [koa](https://www.npmjs.com/package/koa) for general use.

--- a/packages/accepts/package.json
+++ b/packages/accepts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/accepts",
-  "description": "accepts rewrite in TypeScript with ESM and CommonJS targets",
+  "description": "accepts rewrite in TypeScript",
   "version": "2.0.4",
   "homepage": "https://tinyhttp.v1rtl.site",
   "funding": {

--- a/packages/content-disposition/README.md
+++ b/packages/content-disposition/README.md
@@ -1,6 +1,6 @@
 # @tinyhttp/content-disposition
 
-> [`content-disposition`](https://github.com/jshttp/content-disposition) rewrite in TypeScript with ESM and CommonJS targets.
+> [`content-disposition`](https://github.com/jshttp/content-disposition) rewrite in TypeScript.
 
 Create and parse HTTP `Content-Disposition` header
 

--- a/packages/content-disposition/package.json
+++ b/packages/content-disposition/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/content-disposition",
-  "description": "content-disposition rewrite in TypeScript with ESM and CommonJS targets",
+  "description": "content-disposition rewrite in TypeScript",
   "version": "2.0.4",
   "homepage": "https://tinyhttp.v1rtl.site",
   "funding": {

--- a/packages/encode-url/README.md
+++ b/packages/encode-url/README.md
@@ -1,6 +1,6 @@
 # @tinyhttp/encode-url
 
-> [`encode-url`](https://github.com/pillarjs/encodeurl) rewrite in TypeScript with ESM and CommonJS targets.
+> [`encode-url`](https://github.com/pillarjs/encodeurl) rewrite in TypeScript.
 
 Encode a URL to a percent-encoded form, excluding already-encoded sequences
 

--- a/packages/encode-url/package.json
+++ b/packages/encode-url/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tinyhttp/encode-url",
   "version": "2.0.3",
-  "description": "encode-url rewrite in TypeScript with ESM and CommonJS targets",
+  "description": "encode-url rewrite in TypeScript",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": "./dist/index.js",

--- a/packages/forwarded/README.md
+++ b/packages/forwarded/README.md
@@ -1,6 +1,6 @@
 # @tinyhttp/forwarded
 
-> [`forwarded`](https://github.com/jshttp/forwarded) rewrite in TypeScript with ESM and CommonJS targets
+> [`forwarded`](https://github.com/jshttp/forwarded) rewrite in TypeScript
 
 Determine address of a proxied request
 

--- a/packages/proxy-addr/README.md
+++ b/packages/proxy-addr/README.md
@@ -1,6 +1,6 @@
 # @tinyhttp/proxyaddr
 
-> [`proxy-addr`](https://github.com/jshttp/proxy-addr) rewrite in TypeScript with ESM and CommonJS targets
+> [`proxy-addr`](https://github.com/jshttp/proxy-addr) rewrite in TypeScript
 
 Determine address of a proxied request
 

--- a/packages/type-is/README.md
+++ b/packages/type-is/README.md
@@ -1,6 +1,6 @@
 # @tinyhttp/type-is
 
-> [`type-is`](https://github.com/jshttp/type-is) rewrite in TypeScript with ESM and CommonJS targets.
+> [`type-is`](https://github.com/jshttp/type-is) rewrite in TypeScript.
 
 Infer the content-type of a request.
 


### PR DESCRIPTION
Fixes #343

---
I did do a global search and replace here, as the same text was used consistently in `package.json` and `README.md`. I left the reference to CommonJS in the main readme, I simply don't know whether or not tinyhttp supports _consuming_ CommonJS modules. :)