### PR TITLE
Fix cookie-signature unsign return type

### DIFF
--- a/packages/cookie-signature/src/index.ts
+++ b/packages/cookie-signature/src/index.ts
@@ -10,7 +10,7 @@ export const sign = (val: string, secret: string): string =>
  * Unsign and decode the given `val` with `secret`,
  * returning `false` if the signature is invalid.
  */
-export const unsign = (val: string, secret: string): string | boolean => {
+export const unsign = (val: string, secret: string): string | false => {
   const str = val.slice(0, val.lastIndexOf('.')),
     mac = sign(str, secret),
     macBuffer = Buffer.from(mac),


### PR DESCRIPTION
`unsign` never returns `true`, so make the return type `string | false` instead. This change allows type-narrowing code like this to work correctly.

```js
const redirectUri = unsign(state, env.COOKIE_SECRET);
if (redirectUri === false) {
  throw new Error('Invalid OAuth state');
}
```