### PR TITLE
Fix: Issue #351 default server host compatibility with IPv6

### DIFF
--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -340,7 +340,7 @@ export class App<
    * @param Server callback after server starts listening
    * @param host server listening host
    */
-  listen(port?: number, cb?: () => void, host = '0.0.0.0'): Server {
+  listen(port?: number, cb?: () => void, host?: string): Server {
     return createServer().on('request', this.attach).listen(port, host, cb)
   }
 }

--- a/tests/core/request.test.ts
+++ b/tests/core/request.test.ts
@@ -47,27 +47,33 @@ describe('Request properties', () => {
   })
 
   describe('Network extensions', () => {
+    const ipHandler = (req, res) => {
+      res.json({
+        ip: req.ip,
+        ips: req.ips
+      })
+    }
+    const options = {
+      settings: {
+        networkExtensions: true
+      }
+    }
     it('IPv4 req.ip & req.ips is being parsed properly', async () => {
-      const { fetch } = InitAppAndTest(
-        (req, res) => {
-          res.json({
-            ip: req.ip,
-            ips: req.ips
-          })
-        },
-        '/',
-        'GET',
-        {
-          settings: {
-            networkExtensions: true
-          }
-        }
-      )
+      const { fetch } = InitAppAndTest(ipHandler, '/', 'GET', options)
 
       const agent = new Agent({ family: 4 }) // ensure IPv4 only
       await fetch('/', { agent }).expect(200, {
         ip: '127.0.0.1',
         ips: ['::ffff:127.0.0.1']
+      })
+    })
+    it('IPv6 req.ip & req.ips is being parsed properly', async () => {
+      const { fetch } = InitAppAndTest(ipHandler, '/', 'GET', options)
+
+      const agent = new Agent({ family: 6 }) // ensure IPv6 only
+      await fetch('/', { agent }).expect(200, {
+        ip: '1',
+        ips: ['::1']
       })
     })
     it('req.protocol is http by default', async () => {
@@ -77,11 +83,7 @@ describe('Request properties', () => {
         },
         '/',
         'GET',
-        {
-          settings: {
-            networkExtensions: true
-          }
-        }
+        options
       )
 
       await fetch('/').expect(200, `protocol: http`)
@@ -93,11 +95,7 @@ describe('Request properties', () => {
         },
         '/',
         'GET',
-        {
-          settings: {
-            networkExtensions: true
-          }
-        }
+        options
       )
 
       await fetch('/').expect(200, `secure: false`)
@@ -109,11 +107,7 @@ describe('Request properties', () => {
         },
         '/',
         'GET',
-        {
-          settings: {
-            networkExtensions: true
-          }
-        }
+        options
       )
 
       await fetch('/').expect(200, `subdomains: `)

--- a/tests/core/request.test.ts
+++ b/tests/core/request.test.ts
@@ -2,6 +2,7 @@ import { describe, it } from '@jest/globals'
 import { InitAppAndTest } from '../../test_helpers/initAppAndTest'
 import { App } from '../../packages/app/src/app'
 import { makeFetch } from 'supertest-fetch'
+import { Agent } from 'http'
 
 describe('Request properties', () => {
   it('should have default HTTP Request properties', async () => {
@@ -46,7 +47,7 @@ describe('Request properties', () => {
   })
 
   describe('Network extensions', () => {
-    it('req.ip & req.ips is being parsed properly', async () => {
+    it('IPv4 req.ip & req.ips is being parsed properly', async () => {
       const { fetch } = InitAppAndTest(
         (req, res) => {
           res.json({
@@ -63,7 +64,8 @@ describe('Request properties', () => {
         }
       )
 
-      await fetch('/').expect(200, {
+      const agent = new Agent({ family: 4 }) // ensure IPv4 only
+      await fetch('/', { agent }).expect(200, {
         ip: '127.0.0.1',
         ips: ['::ffff:127.0.0.1']
       })


### PR DESCRIPTION
Closes #351 by un-defining the default server host name and adds a new test which passes on dual-stack machines.

Sadly, this may not be testable on GitHub due to actions/virtual-environments#668.