### PR TITLE
fix: prevent res.sendFile() from overwriting 'Content-Type' header if previously set

### DIFF
--- a/packages/send/src/sendFile.ts
+++ b/packages/send/src/sendFile.ts
@@ -34,7 +34,7 @@ export type Caching = Partial<{
 
 type Req = Pick<I, 'headers'>
 
-type Res = Pick<S, 'setHeader' | 'statusCode' | 'writeHead'> & NodeJS.WritableStream
+type Res = Pick<S, 'setHeader' | 'statusCode' | 'writeHead' | 'getHeader'> & NodeJS.WritableStream
 
 export const enableCaching = (res: Res, caching: Caching): void => {
   let cc = caching.maxAge != null && `public,max-age=${caching.maxAge}`
@@ -70,9 +70,9 @@ export const sendFile =
 
     headers['Last-Modified'] = stats.mtime.toUTCString()
 
-    headers['Content-Type'] = contentType(extname(path))
-
     headers['ETag'] = createETag(stats, encoding)
+
+    if (!res.getHeader('Content-Type')) headers['Content-Type'] = contentType(extname(path))
 
     let status = res.statusCode || 200
 

--- a/tests/modules/send.test.ts
+++ b/tests/modules/send.test.ts
@@ -183,6 +183,15 @@ describe('sendFile(path)', () => {
 
     await makeFetch(app)('/').expectHeader('Content-Type', 'text/plain; charset=utf-8')
   })
+  it('should inherit the previously set Content-Type header', async () => {
+    const app = runServer((req, res) => {
+      res.setHeader('Content-Type', 'text/markdown')
+
+      sendFile(req, res)(testFilePath, {})
+    })
+
+    await makeFetch(app)('/').expectHeader('Content-Type', 'text/markdown')
+  })
   it('should allow custom headers through the options param', async () => {
     const HEADER_NAME = 'Test-Header'
     const HEADER_VALUE = 'Hello World'


### PR DESCRIPTION
This PR aims to resolve [Issue#360](https://github.com/tinyhttp/tinyhttp/issues/360).

In sendFile.ts, I added a check to see if the "Content-Type" header had been previously set, and it will only pull the MIME type from the file if the header has not been set.

I then added an extra test inside send.test.ts, where it sets the "Content-Type" header to text/markdown for a text/plain file, to see if it persists. 

Please let me know if any advice/ changes required. 

Thanks!