### PR TITLE
Send valid response when requested MIME type is unsupported

### DIFF
--- a/packages/res/src/redirect.ts
+++ b/packages/res/src/redirect.ts
@@ -15,7 +15,7 @@ export const redirect =
     let address = url
     status = status || 302
 
-    let body: string
+    let body = ''
 
     address = setLocationHeader(req, res)(address).getHeader('Location') as string
 

--- a/packages/res/src/redirect.ts
+++ b/packages/res/src/redirect.ts
@@ -15,7 +15,7 @@ export const redirect =
     let address = url
     status = status || 302
 
-    let body = ''
+    let body: string
 
     address = setLocationHeader(req, res)(address).getHeader('Location') as string
 
@@ -31,6 +31,9 @@ export const redirect =
         const u = escapeHTML(address)
 
         body = `<p>${STATUS_CODES[status]}. Redirecting to <a href="${u}">${u}</a></p>`
+      },
+      default: () => {
+        body = ''
       }
     })
 

--- a/tests/modules/res.test.ts
+++ b/tests/modules/res.test.ts
@@ -129,6 +129,18 @@ describe('Response extensions', () => {
         }
       }).expect(302, '<p>Found. Redirecting to <a href="/abc">/abc</a></p>')
     })
+    it('should send an empty response for unsupported MIME types', async () => {
+      const app = runServer((req, res) => {
+        redirect(req, res, (err) => res.writeHead(err.status).end(err.message))('/abc').end()
+      })
+
+      await makeFetch(app)('/', {
+        redirect: 'manual',
+        headers: {
+          Accept: 'image/jpeg,image/webp'
+        }
+      }).expect(302, '')
+    })
   })
   describe('res.format(obj)', () => {
     it('should send text by default', async () => {


### PR DESCRIPTION
# Description
This PR attempts to resolve issue #345 in the **res** package

## What is the current behavior?
The server responds with a 406 (Not Acceptable) error when the client requests an unsupported MIME-type

## What is the new behavior?
A valid response with an empty body is sent to the client

Fixes #345