### PR TITLE
Correct type declaration

### DIFF
--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -48,7 +48,7 @@ export type TemplateFunc<O> = (
   path: string,
   locals: Record<string, any>,
   opts: TemplateEngineOptions<O>,
-  cb: (err: Error, html: unknown) => void
+  cb: (err: Error | null, html: unknown) => void
 ) => void
 
 export type TemplateEngineOptions<O> = Partial<{
@@ -87,7 +87,7 @@ export class App<
   Res extends Response<RenderOptions> = Response<RenderOptions>
 > extends Router<App, Req, Res> {
   middleware: Middleware<Req, Res>[] = []
-  locals: Record<string, string> = {}
+  locals: Record<string, any> = {}
   noMatchHandler: Handler
   onError: ErrorHandler
   settings: AppSettings

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -87,7 +87,7 @@ export class App<
   Res extends Response<RenderOptions> = Response<RenderOptions>
 > extends Router<App, Req, Res> {
   middleware: Middleware<Req, Res>[] = []
-  locals: Record<string, any> = {}
+  locals: Record<string, unknown> = {}
   noMatchHandler: Handler
   onError: ErrorHandler
   settings: AppSettings


### PR DESCRIPTION
* App.locals should be `Record<string any>` because the app doesn't really care about the values, it just pass them to functions. They can even be `<string, unknown>`.
* Callback for template rendering function should be `(error: Error | null, html: unknown) => void` because error can be null.