### PR TITLE
fix: skip ipv6 tests only for github cicd #351

### DIFF
--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -341,7 +341,7 @@ export class App<
    * @param Server callback after server starts listening
    * @param host server listening host
    */
-  listen(port?: number, cb?: () => void, host = '0.0.0.0'): Server {
+  listen(port?: number, cb?: () => void, host?: string): Server {
     return createServer().on('request', this.attach).listen(port, host, cb)
   }
 }


### PR DESCRIPTION
As stated [before](https://github.com/tinyhttp/tinyhttp/pull/352#issue-1181241448), ipv6 fails on github actions. The tests are skipped by checking for default environment variables that action uses. Also, closes #351 