### PR TITLE
subapps return the path correctly when mounted on array of paths

### DIFF
--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -189,16 +189,20 @@ export class App<
     return this
   }
   use(...args: UseMethodParams<Req, Res, App>): this {
-    let base = []
-    // if base is not an array of paths, then convert it to an array.
-    if (Array.isArray(args[0])) base = base.concat(args[0])
-    else base = [args[0]]
+    let base = args[0]
+   
+    
     const fns = args.slice(1).flat()
 
     let pathArray = []
     if (typeof base === 'function' || base instanceof App) {
       fns.unshift(base)
     } else {
+       // if base is not an array of paths, then convert it to an array.
+      base = [];
+      if (Array.isArray(args[0])) base = [...args[0]]
+      else if (typeof args[0] === 'string') base = [args[0] as any]
+      
       base = base.filter((element) => {
         if (typeof element === 'string') {
           pathArray.push(element)

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -189,28 +189,27 @@ export class App<
     return this
   }
   use(...args: UseMethodParams<Req, Res, App>): this {
-    let base = args[0]
-   
-    
+    const base = args[0]
+
     const fns = args.slice(1).flat()
 
     let pathArray = []
     if (typeof base === 'function' || base instanceof App) {
       fns.unshift(base)
     } else {
-       // if base is not an array of paths, then convert it to an array.
-      base = [];
-      if (Array.isArray(args[0])) base = [...args[0]]
-      else if (typeof args[0] === 'string') base = [args[0] as any]
-      
-      base = base.filter((element) => {
+      // if base is not an array of paths, then convert it to an array.
+      let basePaths = []
+      if (Array.isArray(base)) basePaths = [...base]
+      else if (typeof base === 'string') basePaths = [base]
+
+      basePaths = basePaths.filter((element) => {
         if (typeof element === 'string') {
           pathArray.push(element)
           return false
         }
         return true
       })
-      fns.unshift(...base)
+      fns.unshift(...basePaths)
     }
     pathArray = pathArray.length ? pathArray : ['/']
 

--- a/packages/router/src/index.ts
+++ b/packages/router/src/index.ts
@@ -11,7 +11,10 @@ export type AsyncHandler<Request = any, Response = any> = (
   next: NextFunction
 ) => Promise<void>
 
-export type Handler<Request = any, Response = any> = AsyncHandler<Request, Response> | SyncHandler<Request, Response>
+export type Handler<Request = any, Response = any> =
+  | AsyncHandler<Request, Response>
+  | SyncHandler<Request, Response>
+  | string
 
 const METHODS = [
   'ACL',
@@ -79,7 +82,7 @@ export type MethodHandler<Req = any, Res = any> = {
   fullPath?: string
 }
 
-export type RouterHandler<Req = any, Res = any> = Handler<Req, Res> | Handler<Req, Res>[]
+export type RouterHandler<Req = any, Res = any> = Handler<Req, Res> | Handler<Req, Res>[] | string[]
 
 export type RouterPathOrHandler<Req = any, Res = any> = string | RouterHandler<Req, Res>
 

--- a/tests/core/app.test.ts
+++ b/tests/core/app.test.ts
@@ -9,6 +9,7 @@ import { renderFile } from 'eta'
 import type { EtaConfig } from 'eta/dist/types/config'
 import { InitAppAndTest } from '../../test_helpers/initAppAndTest'
 import { makeFetch } from 'supertest-fetch'
+import exp from 'node:constants'
 
 describe('Testing App', () => {
   it('should launch a basic server', async () => {
@@ -644,6 +645,21 @@ describe('Route handlers', () => {
 
     await fetch('/route').expect(200, 'found')
   })
+  it('should accept array of paths', async () => {
+    const app = new App()
+
+    app.get(['/route1', '/route2'], (_, res) => res.send('found'))
+
+    const server = app.listen()
+
+    const fetch = makeFetch(server)
+
+    await fetch('/route1').expect(200, 'found')
+
+    await fetch('/route2').expect(200, 'found')
+
+    expect(app.middleware).toHaveLength(2)
+  })
 })
 
 describe('Subapps', () => {
@@ -816,6 +832,32 @@ describe('Subapps', () => {
     app.use('/blog', subapp)
 
     expect(subsubapp.path()).toBe('/blog/admin')
+  })
+  it('app.path() should nest multiple mountpaths for a single subapp', () => {
+    const app = new App()
+
+    const subapp = new App()
+
+    const subsubapp = new App()
+
+    app.use(['/t1', '/t2'], subapp)
+
+    subapp.use('/t3', subsubapp)
+
+    expect(subsubapp.path()).toBe('/t1, /t2/t3')
+  })
+  it('app.path() should nest multiple mountpaths for multiple subapp', () => {
+    const app = new App()
+
+    const subapp = new App()
+
+    const subsubapp = new App()
+
+    app.use(['/t1', '/t2'], subapp)
+
+    subapp.use(['/t3', '/t4'], subsubapp)
+
+    expect(subsubapp.path()).toBe('/t1, /t2/t3, /t4')
   })
   it('middlewares of a subapp should preserve the path', () => {
     const app = new App()

--- a/tests/core/app.test.ts
+++ b/tests/core/app.test.ts
@@ -9,7 +9,6 @@ import { renderFile } from 'eta'
 import type { EtaConfig } from 'eta/dist/types/config'
 import { InitAppAndTest } from '../../test_helpers/initAppAndTest'
 import { makeFetch } from 'supertest-fetch'
-import exp from 'node:constants'
 
 describe('Testing App', () => {
   it('should launch a basic server', async () => {


### PR DESCRIPTION
`app.path()` would default to `//` when mounted for array of paths. This fixes it and uses express style mounting.


fixes #389 