### PR TITLE
fix res.json() to accept non-object input

### DIFF
--- a/packages/send/src/json.ts
+++ b/packages/send/src/json.ts
@@ -10,13 +10,12 @@ export const json =
   <Response extends Res = Res>(res: Response) =>
   (body: any, ...args: any[]): Response => {
     res.setHeader('Content-Type', 'application/json')
-    if (typeof body === 'object' && body != null) res.end(JSON.stringify(body, null, 2), ...args)
-    else if (typeof body === 'string') res.end(body, ...args)
-    else if (body == null) {
+    if (body == null) {
       res.removeHeader('Content-Length')
       res.removeHeader('Transfer-Encoding')
       res.end(null, ...args)
-    }
+    } else if (typeof body === 'string') res.end(body, ...args)
+    else res.end(JSON.stringify(body, null, 2), ...args) 
 
     return res
   }

--- a/packages/send/src/json.ts
+++ b/packages/send/src/json.ts
@@ -8,14 +8,14 @@ type Res = Pick<S, 'setHeader' | 'end' | 'removeHeader'>
  */
 export const json =
   <Response extends Res = Res>(res: Response) =>
-  (body: any, ...args: any[]): Response => {
+  (body: unknown, cb?: () => void): Response => {
     res.setHeader('Content-Type', 'application/json')
     if (body == null) {
       res.removeHeader('Content-Length')
       res.removeHeader('Transfer-Encoding')
-      res.end(null, ...args)
-    } else if (typeof body === 'string') res.end(body, ...args)
-    else res.end(JSON.stringify(body, null, 2), ...args) 
+      res.end(null, cb)
+    } else if (typeof body === 'string') res.end(body, cb)
+    else res.end(JSON.stringify(body, null, 2), cb)
 
     return res
   }


### PR DESCRIPTION
Just like the express.js documentation, the [tinyhttp documentation](https://tinyhttp.v1rtl.site/docs/api/response.html#res-json) says
> Sends a JSON response. This method sends a response (with the correct `Content-Type` header) that is the parameter converted to a JSON string using [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify).
>
> The body can be any kind of JSON, including `object`, `array`, `string`, `boolean`, `number`, or `null`.

However, only Objects (incl. Arrays), `null` and `undefined` are currently supported. Also, the current implementation has an undocumented special handling of Strings, simply assuming they are JSON strings instead of using `JSON.stringify()` (as the documentation explicitly says and as express.js does; i would argue: as users would reasonably expect).

In short: neither `res.json(true)` nor `res.json(123)` works yet.

This PR fixes the current implementation to also support inputs of type `boolean` and `number`. It does not remove the special handling of `string` inputs, as this would be a breaking change (though IMO that should be done for the next major version).

As it should pass linter tests, this PR also replaces `any` types. This breaks the signature `res.send(body: string, encoding: BufferEncoding, cb?: () => void)`, which I can only imagine being not much of a big deal.

Only the **send package** is affected.

As a positive side effect, this PR reduces the code size.