### PR TITLE
Feat/trust proxy

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/app",
-  "version": "2.2.4",
+  "version": "2.3.0",
   "description": "0-legacy, tiny & fast web framework as a replacement of Express",
   "type": "module",
   "homepage": "https://tinyhttp.v1rtl.site",

--- a/packages/app/src/app.ts
+++ b/packages/app/src/app.ts
@@ -75,6 +75,7 @@ export class App<Req extends Request = Request, Res extends Response = Response>
       xPoweredBy: true,
       views: `${process.cwd()}/views`,
       'view cache': process.env.NODE_ENV === 'production',
+      'trust proxy': 0,
       ...options.settings
     }
     this.applyExtensions = options?.applyExtensions

--- a/packages/app/src/extend.ts
+++ b/packages/app/src/extend.ts
@@ -1,3 +1,4 @@
+import { compile } from '@tinyhttp/proxy-addr'
 import {
   checkIfXMLHttpRequest,
   getAccepts,
@@ -54,12 +55,12 @@ export const extendMiddleware =
     }
 
     if (settings?.networkExtensions) {
-      req.protocol = getProtocol(req)
+      req.protocol = getProtocol(req, trust)
       req.secure = req.protocol === 'https'
-      req.hostname = getHostname(req)
-      req.subdomains = getSubdomains(req, settings.subdomainOffset)
-      req.ip = getIP(req)
-      req.ips = getIPs(req)
+      req.hostname = getHostname(req, trust)
+      req.subdomains = getSubdomains(req, trust, settings.subdomainOffset)
+      req.ip = getIP(req, trust)
+      req.ips = getIPs(req, trust)
     }
 
     req.query = getQueryParams(req.url)

--- a/packages/app/src/extend.ts
+++ b/packages/app/src/extend.ts
@@ -54,6 +54,12 @@ export const extendMiddleware =
       res.app = app
     }
 
+    let trust = settings?.['trust proxy']
+    if (typeof trust !== 'function') {
+      trust = compile(trust)
+      settings['trust proxy'] = trust
+    }
+
     if (settings?.networkExtensions) {
       req.protocol = getProtocol(req, trust)
       req.secure = req.protocol === 'https'

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -1,3 +1,4 @@
+import type { Trust } from '@tinyhttp/proxy-addr'
 import type { Handler, NextFunction } from '@tinyhttp/router'
 import type { ErrorHandler } from './onError.js'
 import type { Request } from './request.js'
@@ -17,6 +18,7 @@ export type AppSettings = Partial<{
   view: typeof View
   'view cache': boolean
   'view engine': string
+  'trust proxy': Trust
 }>
 
 export type TemplateEngineOptions = {

--- a/packages/jsonp/package.json
+++ b/packages/jsonp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/jsonp",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "type": "module",
   "description": "JSONP response middleware",
   "homepage": "https://tinyhttp.v1rtl.site",

--- a/packages/proxy-addr/package.json
+++ b/packages/proxy-addr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinyhttp/proxy-addr",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "type": "module",
   "description": "proxy-addr rewrite with TypeScript and ESM support",
   "homepage": "https://tinyhttp.v1rtl.site",

--- a/packages/proxy-addr/src/index.ts
+++ b/packages/proxy-addr/src/index.ts
@@ -80,10 +80,7 @@ function compile(val: string | number | (string | number)[]): (addr: string) => 
  * Compile `arr` elements into range subnets.
  */
 function compileRangeSubnets(arr: string[]) {
-  const rangeSubnets = new Array(arr.length)
-  for (let i = 0; i < arr.length; i++) rangeSubnets[i] = parseIPNotation(arr[i])
-
-  return rangeSubnets
+  return arr.map(parseIPNotation)
 }
 /**
  * Compile range subnet array into trust function.

--- a/packages/proxy-addr/src/index.ts
+++ b/packages/proxy-addr/src/index.ts
@@ -55,12 +55,12 @@ const trustNone = () => false
  * @param req
  * @param trust
  */
-function alladdrs(req: Req, trust: Trust): string[] {
+function alladdrs(req: Req, trust?: Trust): string[] {
   // get addresses
 
   const addrs = forwarded(req)
 
-  if (!trust) return addrs
+  if (trust == null) return addrs
 
   if (typeof trust !== 'function') trust = compile(trust)
 

--- a/packages/proxy-addr/src/index.ts
+++ b/packages/proxy-addr/src/index.ts
@@ -106,7 +106,7 @@ function compileHopsTrust(hops: number): (_: string, i: number) => boolean {
  * Compile `arr` elements into range subnets.
  */
 function compileRangeSubnets(arr: string[]) {
-  return arr.map(ip => parseIPNotation(ip))
+  return arr.map((ip) => parseIPNotation(ip))
 }
 /**
  * Compile range subnet array into trust function.

--- a/packages/proxy-addr/src/index.ts
+++ b/packages/proxy-addr/src/index.ts
@@ -106,7 +106,7 @@ function compileHopsTrust(hops: number): (_: string, i: number) => boolean {
  * Compile `arr` elements into range subnets.
  */
 function compileRangeSubnets(arr: string[]) {
-  return arr.map(parseIPNotation)
+  return arr.map(ip => parseIPNotation(ip))
 }
 /**
  * Compile range subnet array into trust function.

--- a/packages/proxy-addr/src/index.ts
+++ b/packages/proxy-addr/src/index.ts
@@ -8,7 +8,7 @@ type Trust = ((addr: string, i: number) => boolean) | number[] | string[] | stri
 
 type Subnet = {
   ip: IPv4 | IPv6
-  range: number | null
+  range?: number
 }
 
 const DIGIT_REGEXP = /^[0-9]+$/
@@ -119,8 +119,8 @@ export function parseIPNotation(note: string): Subnet {
 
   const max = ip.kind() === 'ipv6' ? 128 : 32
 
-  const rangeString: string = pos !== -1 ? note.substring(pos + 1, note.length) : null
-  let range: number
+  const rangeString: string | null = pos !== -1 ? note.substring(pos + 1, note.length) : null
+  let range: number | null
 
   if (rangeString === null) range = max
   else if (DIGIT_REGEXP.test(rangeString)) range = Number.parseInt(rangeString, 10)
@@ -129,7 +129,7 @@ export function parseIPNotation(note: string): Subnet {
 
   if (typeof range === 'number' && (range <= 0 || range > max)) throw new TypeError(`invalid range on address: ${note}`)
 
-  return { ip, range }
+  return { ip, range: range ?? undefined }
 }
 /**
  * Parse netmask string into CIDR range.
@@ -161,7 +161,7 @@ function trustMulti(subnets: Subnet[]) {
   return function trust(addr: string) {
     if (!isip(addr)) return false
     const ip = parseip(addr)
-    let ipconv: IPv4 | IPv6
+    let ipconv: IPv4 | IPv6 | null = null
     const kind = ip.kind()
     for (let i = 0; i < subnets.length; i++) {
       const subnet = subnets[i]

--- a/packages/proxy-addr/src/index.ts
+++ b/packages/proxy-addr/src/index.ts
@@ -79,7 +79,7 @@ function compile(val: string | number | string[]): (addr: string, i: number) => 
   let trust: string[]
   if (typeof val === 'string') trust = [val]
   else if (typeof val === 'number') return compileHopsTrust(val)
-  else if (Array.isArray(val)) trust = val
+  else if (Array.isArray(val)) trust = val.slice()
   else throw new TypeError('unsupported trust argument')
 
   for (let i = 0; i < trust.length; i++) {

--- a/packages/proxy-addr/src/index.ts
+++ b/packages/proxy-addr/src/index.ts
@@ -40,7 +40,7 @@ const trustNone = () => false
  * Get all addresses in the request, optionally stopping
  * at the first untrusted.
  *
- * @param request
+ * @param req
  * @param trust
  */
 function alladdrs(req: Req, trust: Trust): string[] {
@@ -144,7 +144,7 @@ function parseNetmask(netmask: string) {
 /**
  * Determine address of proxied request.
  *
- * @param request
+ * @param req
  * @param trust
  * @public
  */

--- a/packages/proxy-addr/tsconfig.json
+++ b/packages/proxy-addr/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "declarationDir": "dist"
+    "declarationDir": "dist",
+    "strict": true
   },
   "include": ["src"],
   "exclude": ["rollup.config.js"]

--- a/test_helpers/createReq.ts
+++ b/test_helpers/createReq.ts
@@ -1,14 +1,10 @@
-export const createReq = (
-  socketAddr: string,
-  headers?: Record<string, string>
-): {
-  socket: {
-    remoteAddress: string
-  }
-  headers: Record<string, string>
-} => ({
-  socket: {
-    remoteAddress: socketAddr
-  },
-  headers: headers || {}
-})
+import type { IncomingMessage } from 'node:http'
+
+export function createReq(socketAddr: string, headers?: Record<string, string>): IncomingMessage {
+  return {
+    socket: {
+      remoteAddress: socketAddr
+    },
+    headers: headers || {}
+  } as IncomingMessage
+}

--- a/test_helpers/createReq.ts
+++ b/test_helpers/createReq.ts
@@ -1,10 +1,9 @@
 import type { IncomingMessage } from 'node:http'
 
-export function createReq(socketAddr: string, headers?: Record<string, string>): IncomingMessage {
-  return {
+export const createReq = (socketAddr: string, headers?: Record<string, string>): IncomingMessage =>
+  ({
     socket: {
       remoteAddress: socketAddr
     },
     headers: headers || {}
-  } as IncomingMessage
-}
+  }) as IncomingMessage

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -69,7 +69,7 @@ describe('proxyaddr(req, trust)', () => {
 
         expect(proxyaddr(req, 'loopback')).toBe('127.0.0.1')
       })
-      it('should accept pre-defined names', () => {
+      it('should accept pre-defined names in an array', () => {
         const req = createReq('127.0.0.1') as IncomingMessage
 
         expect(proxyaddr(req, ['loopback', '10.0.0.1'])).toBe('127.0.0.1')

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -102,71 +102,36 @@ describe('proxyaddr(req, trust)', () => {
           expect(e.message).toContain('invalid IP address')
         }
       })
-      it('should reject bad CIDR', () => {
+      it.each(['10.0.0.1/internet', '10.0.0.1/6000', '::1/6000', '::ffff:a00:2/136', '::ffff:a00:2/-1'])(
+        "should reject bad CIDR '%s'",
+        (trust: string) => {
+          const req = createReq('127.0.0.1')
+
+          try {
+            proxyaddr(req, trust)
+          } catch (e) {
+            expect(e.message).toContain('invalid range on address')
+            return
+          }
+          assert.fail()
+        }
+      )
+      it.each([
+        '10.0.0.1/255.0.255.0',
+        '10.0.0.1/ffc0::',
+        'fe80::/ffc0::',
+        'fe80::/255.255.255.0',
+        '::ffff:a00:2/255.255.255.0'
+      ])("should reject bad netmask '%s'", (netmask: string) => {
         const req = createReq('127.0.0.1')
 
         try {
-          proxyaddr(req, '10.0.0.1/internet')
+          proxyaddr(req, netmask)
         } catch (e) {
           expect(e.message).toContain('invalid range on address')
+          return
         }
-
-        try {
-          proxyaddr(req, '10.0.0.1/6000')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
-
-        try {
-          proxyaddr(req, '::1/6000')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
-
-        try {
-          proxyaddr(req, '::ffff:a00:2/136')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
-
-        try {
-          proxyaddr(req, '::ffff:a00:2/-1')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
-      })
-      it('should reject bad netmask', () => {
-        const req = createReq('127.0.0.1')
-
-        try {
-          proxyaddr(req, '10.0.0.1/255.0.255.0')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
-
-        try {
-          proxyaddr(req, '10.0.0.1/ffc0::')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
-
-        try {
-          proxyaddr(req, 'fe80::/ffc0::')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
-
-        try {
-          proxyaddr(req, 'fe80::/255.255.255.0')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
-
-        try {
-          proxyaddr(req, '::ffff:a00:2/255.255.255.0')
-        } catch (e) {
-          expect(e.message).toContain('invalid range on address')
-        }
+        assert.fail()
       })
       it('should be invoked as trust(addr, i)', () => {
         const log = []
@@ -582,7 +547,7 @@ describe('proxyaddr.compile(trust)', () => {
       it('should accept pre-defined names in an array', () => {
         expect(compile(['loopback', '10.0.0.1'])).toBeTypeOf('function')
       })
-      it.each(['blargh', '-1'])('should reject non-IP', (value: string) => {
+      it.each(['blargh', '-1'])("should reject non-IP '%s'", (value: string) => {
         try {
           compile(value)
         } catch (error) {
@@ -594,7 +559,7 @@ describe('proxyaddr.compile(trust)', () => {
       })
 
       it.each(['10.0.0.1/6000', '::1/6000', '::ffff:a00:2/136', '::ffff:a00:2/-1'])(
-        'should reject bad CIDR',
+        "should reject bad CIDR '%s'",
         (value: string) => {
           try {
             compile(value)

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -381,6 +381,25 @@ describe('proxyaddr(req, trust)', () => {
 
       expect(proxyaddr(req, ['::ffff:a00:1', '::ffff:a00:2'])).toBe('192.168.0.1')
     })
+    it('should match CIDR notation for IPv4-mapped address', () => {})
+    it('should match CIDR notation for IPv4-mapped address mixed with IPv6 CIDR', () => {})
+    it('should match CIDR notation for IPv4-mapped address mixed with IPv4 addresses', () => {})
+  })
+
+  describe('when given pre-defined names', () => {
+    it('should accept single pre-defined name', () => {})
+    it('should accept multiple pre-defined names', () => {})
+  })
+
+  describe('when header contains non-ip addresses', () => {
+    it('should stop at first non-trusted non-ip', () => {})
+    it('should stop at first non-trusted malformed ip', () => {})
+    it('should provide all values to function', () => {})
+  })
+
+  describe('when socket address undefined', () => {
+    it('should return undefined as address', () => {})
+    it('should return undefined even with trusted headers', () => {})
   })
 
   describe('when given number', () => {
@@ -396,6 +415,49 @@ describe('proxyaddr(req, trust)', () => {
       it(`should use the address that is at most ${trust} hops away`, () => {
         expect(proxyaddr(req, trust)).toBe(address)
       })
+    })
+  })
+})
+
+describe('proxyaddr.all(req, trust?)', () => {
+  describe('arguments', () => {
+    describe('req', () => {
+      it('should be required', () => {})
+    })
+    describe('trust', () => {
+      it('should be optional', () => {})
+    })
+  })
+
+  describe('with no headers', () => {
+    it('should return socket address', () => {})
+  })
+
+  describe('with x-forwarded-for header', () => {
+    it('should include x-forwarded-for', () => {})
+    it('should include x-forwarded-for in the correct order', () => {})
+  })
+
+  describe('with trust argument', () => {
+    it('should stop at first untrusted', () => {})
+    it('should return only socket address when nothing is trusted', () => {})
+  })
+})
+
+describe('proxyaddr.compile(trust)', () => {
+  describe('arguments', () => {
+    describe('trust', () => {
+      it('should be required', () => {})
+      it('should accept a string array', () => {})
+      it('should accept a number', () => {})
+      it('should accept IPv4', () => {})
+      it('should accept IPv6', () => {})
+      it('should accept IPv4-style IPv6', () => {})
+      it('should accept pre-defined names', () => {})
+      it('should accept pre-defined names in an array', () => {})
+      it('should reject non-IP', () => {})
+      it('should reject bad CIDR', () => {})
+      it('should not alter input array', () => {})
     })
   })
 })

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -1,17 +1,14 @@
 // Original test cases are taken from https://github.com/jshttp/proxy-addr/blob/master/test/test.js
 
-import type { IncomingMessage } from 'node:http'
 import { describe, expect, it } from 'vitest'
-import { proxyaddr } from '../../packages/proxy-addr/src'
+import { all, compile, proxyaddr } from '../../packages/proxy-addr/src'
 import { createReq } from '../../test_helpers/createReq'
 
-const all = () => true
+const trustAll = () => true
 
-const none = () => false
+const trustNone = () => false
 
-function trust10x(addr: string) {
-  return /^10\./.test(addr)
-}
+const trust10x = (addr: string) => /^10\./.test(addr)
 
 describe('proxyaddr(req, trust)', () => {
   describe('arguments', () => {
@@ -37,7 +34,7 @@ describe('proxyaddr(req, trust)', () => {
       it('should accept a function', () => {
         const req = createReq('127.0.0.1')
 
-        expect(proxyaddr(req, all)).toBe('127.0.0.1')
+        expect(proxyaddr(req, trustAll)).toBe('127.0.0.1')
       })
       it('should accept an array', () => {
         const req = createReq('127.0.0.1')
@@ -195,21 +192,21 @@ describe('proxyaddr(req, trust)', () => {
     it('should return socket address with no headers', () => {
       const req = createReq('127.0.0.1')
 
-      expect(proxyaddr(req, all)).toBe('127.0.0.1')
+      expect(proxyaddr(req, trustAll)).toBe('127.0.0.1')
     })
     it('should return header value', () => {
       const req = createReq('127.0.0.1', {
         'x-forwarded-for': '10.0.0.1'
       })
 
-      expect(proxyaddr(req, all)).toBe('10.0.0.1')
+      expect(proxyaddr(req, trustAll)).toBe('10.0.0.1')
     })
     it('should return furthest header value', () => {
       const req = createReq('127.0.0.1', {
         'x-forwarded-for': '10.0.0.1, 10.0.0.2'
       })
 
-      expect(proxyaddr(req, all)).toBe('10.0.0.1')
+      expect(proxyaddr(req, trustAll)).toBe('10.0.0.1')
     })
   })
 
@@ -217,14 +214,14 @@ describe('proxyaddr(req, trust)', () => {
     it('should return socket address with no headers', () => {
       const req = createReq('127.0.0.1')
 
-      expect(proxyaddr(req, none)).toBe('127.0.0.1')
+      expect(proxyaddr(req, trustNone)).toBe('127.0.0.1')
     })
     it('should return socket address with headers', () => {
       const req = createReq('127.0.0.1', {
         'x-forwarded-for': '10.0.0.1'
       })
 
-      expect(proxyaddr(req, none)).toBe('127.0.0.1')
+      expect(proxyaddr(req, trustNone)).toBe('127.0.0.1')
     })
   })
 

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -293,7 +293,7 @@ describe('proxyaddr(req, trust)', () => {
 
         expect(proxyaddr(req, [])).toBe('127.0.0.1')
       })
-      it('should return socket address', () => {
+      it('should return socket address with headers', () => {
         const req = createReq('127.0.0.1', {
           'x-forwarded-for': '10.0.0.1, 10.0.0.2'
         }) as IncomingMessage

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -15,6 +15,16 @@ function trust10x(addr: string) {
 
 describe('proxyaddr(req, trust)', () => {
   describe('arguments', () => {
+    describe('req', () => {
+      it('should be required', () => {
+        try {
+          proxyaddr(null, null)
+        } catch (error) {
+          expect(error).toBeDefined()
+        }
+      })
+    })
+
     describe('trust', () => {
       it('should accept a function', () => {
         const req = createReq('127.0.0.1') as IncomingMessage

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -164,7 +164,8 @@ describe('proxyaddr(req, trust)', () => {
         }) as IncomingMessage
 
         proxyaddr(req, (addr, i) => {
-          return log.push([addr, i])
+          log.push([addr, i])
+          return true
         })
 
         expect(log).toStrictEqual([

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -14,154 +14,157 @@ function trust10x(addr: string) {
 }
 
 describe('proxyaddr(req, trust)', () => {
-  describe('trust', () => {
-    it('should accept a function', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
+  describe('arguments', () => {
+    describe('trust', () => {
+      it('should accept a function', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
 
-      expect(proxyaddr(req, all)).toBe('127.0.0.1')
-    })
-    it('should accept an array', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      expect(proxyaddr(req, [])).toBe('127.0.0.1')
-    })
-    it('should accept a number', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      expect(proxyaddr(req, 1)).toBe('127.0.0.1')
-    })
-    it('should accept IPv4', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      expect(proxyaddr(req, '127.0.0.1')).toBe('127.0.0.1')
-    })
-    it('should accept IPv6', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      expect(proxyaddr(req, '::1')).toBe('127.0.0.1')
-    })
-    it('should accept IPv4-style IPv6', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      expect(proxyaddr(req, '::ffff:127.0.0.1')).toBe('127.0.0.1')
-    })
-    it('should accept pre-defined names', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      expect(proxyaddr(req, 'loopback')).toBe('127.0.0.1')
-    })
-    it('should accept pre-defined names', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      expect(proxyaddr(req, ['loopback', '10.0.0.1'])).toBe('127.0.0.1')
-    })
-    it('should reject non-IP', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      try {
-        proxyaddr(req, 'blegh')
-      } catch (e) {
-        expect(e.message).toContain('invalid IP address')
-      }
-      try {
-        proxyaddr(req, '10.0.300.1')
-      } catch (e) {
-        expect(e.message).toContain('invalid IP address')
-      }
-      try {
-        proxyaddr(req, '::ffff:30.168.1.9000')
-      } catch (e) {
-        expect(e.message).toContain('invalid IP address')
-      }
-      try {
-        proxyaddr(req, '-1')
-      } catch (e) {
-        expect(e.message).toContain('invalid IP address')
-      }
-    })
-    it('should reject bad CIDR', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      try {
-        proxyaddr(req, '10.0.0.1/internet')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-
-      try {
-        proxyaddr(req, '10.0.0.1/6000')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-
-      try {
-        proxyaddr(req, '::1/6000')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-
-      try {
-        proxyaddr(req, '::ffff:a00:2/136')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-
-      try {
-        proxyaddr(req, '::ffff:a00:2/-1')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-    })
-    it('should reject bad netmask', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
-
-      try {
-        proxyaddr(req, '10.0.0.1/255.0.255.0')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-
-      try {
-        proxyaddr(req, '10.0.0.1/ffc0::')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-
-      try {
-        proxyaddr(req, 'fe80::/ffc0::')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-
-      try {
-        proxyaddr(req, 'fe80::/255.255.255.0')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-
-      try {
-        proxyaddr(req, '::ffff:a00:2/255.255.255.0')
-      } catch (e) {
-        expect(e.message).toContain('invalid range on address')
-      }
-    })
-    it('should be invoked as trust(addr, i)', () => {
-      const log = []
-
-      const req = createReq('127.0.0.1', {
-        'x-forwarded-for': '192.168.0.1, 10.0.0.1'
-      }) as IncomingMessage
-
-      proxyaddr(req, (addr, i) => {
-        return log.push([addr, i])
+        expect(proxyaddr(req, all)).toBe('127.0.0.1')
       })
+      it('should accept an array', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
 
-      expect(log).toStrictEqual([
-        ['127.0.0.1', 0],
-        ['10.0.0.1', 1]
-      ])
+        expect(proxyaddr(req, [])).toBe('127.0.0.1')
+      })
+      it('should accept a number', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        expect(proxyaddr(req, 1)).toBe('127.0.0.1')
+      })
+      it('should accept IPv4', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        expect(proxyaddr(req, '127.0.0.1')).toBe('127.0.0.1')
+      })
+      it('should accept IPv6', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        expect(proxyaddr(req, '::1')).toBe('127.0.0.1')
+      })
+      it('should accept IPv4-style IPv6', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        expect(proxyaddr(req, '::ffff:127.0.0.1')).toBe('127.0.0.1')
+      })
+      it('should accept pre-defined names', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        expect(proxyaddr(req, 'loopback')).toBe('127.0.0.1')
+      })
+      it('should accept pre-defined names', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        expect(proxyaddr(req, ['loopback', '10.0.0.1'])).toBe('127.0.0.1')
+      })
+      it('should reject non-IP', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        try {
+          proxyaddr(req, 'blegh')
+        } catch (e) {
+          expect(e.message).toContain('invalid IP address')
+        }
+        try {
+          proxyaddr(req, '10.0.300.1')
+        } catch (e) {
+          expect(e.message).toContain('invalid IP address')
+        }
+        try {
+          proxyaddr(req, '::ffff:30.168.1.9000')
+        } catch (e) {
+          expect(e.message).toContain('invalid IP address')
+        }
+        try {
+          proxyaddr(req, '-1')
+        } catch (e) {
+          expect(e.message).toContain('invalid IP address')
+        }
+      })
+      it('should reject bad CIDR', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        try {
+          proxyaddr(req, '10.0.0.1/internet')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+
+        try {
+          proxyaddr(req, '10.0.0.1/6000')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+
+        try {
+          proxyaddr(req, '::1/6000')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+
+        try {
+          proxyaddr(req, '::ffff:a00:2/136')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+
+        try {
+          proxyaddr(req, '::ffff:a00:2/-1')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+      })
+      it('should reject bad netmask', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        try {
+          proxyaddr(req, '10.0.0.1/255.0.255.0')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+
+        try {
+          proxyaddr(req, '10.0.0.1/ffc0::')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+
+        try {
+          proxyaddr(req, 'fe80::/ffc0::')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+
+        try {
+          proxyaddr(req, 'fe80::/255.255.255.0')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+
+        try {
+          proxyaddr(req, '::ffff:a00:2/255.255.255.0')
+        } catch (e) {
+          expect(e.message).toContain('invalid range on address')
+        }
+      })
+      it('should be invoked as trust(addr, i)', () => {
+        const log = []
+
+        const req = createReq('127.0.0.1', {
+          'x-forwarded-for': '192.168.0.1, 10.0.0.1'
+        }) as IncomingMessage
+
+        proxyaddr(req, (addr, i) => {
+          return log.push([addr, i])
+        })
+
+        expect(log).toStrictEqual([
+          ['127.0.0.1', 0],
+          ['10.0.0.1', 1]
+        ])
+      })
     })
   })
+
   describe('with all trusted', () => {
     it('should return socket address with no headers', () => {
       const req = createReq('127.0.0.1') as IncomingMessage

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -26,6 +26,14 @@ describe('proxyaddr(req, trust)', () => {
     })
 
     describe('trust', () => {
+      it('should be required', () => {
+        const req = createReq('127.0.0.1') as IncomingMessage
+        try {
+          proxyaddr(req, null)
+        } catch (error) {
+          expect(error).toBeDefined()
+        }
+      })
       it('should accept a function', () => {
         const req = createReq('127.0.0.1') as IncomingMessage
 

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -27,7 +27,7 @@ describe('proxyaddr(req, trust)', () => {
 
     describe('trust', () => {
       it('should be required', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
         try {
           proxyaddr(req, null)
         } catch (error) {
@@ -35,54 +35,54 @@ describe('proxyaddr(req, trust)', () => {
         }
       })
       it('should accept a function', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, all)).toBe('127.0.0.1')
       })
       it('should accept an array', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, [])).toBe('127.0.0.1')
       })
       it('should accept a number', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, 1)).toBe('127.0.0.1')
       })
       it('should accept IPv4', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, '127.0.0.1')).toBe('127.0.0.1')
       })
       it('should accept IPv6', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, '::1')).toBe('127.0.0.1')
       })
       it('should accept IPv4-style IPv6', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, '::ffff:127.0.0.1')).toBe('127.0.0.1')
       })
       it('should accept pre-defined names', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, 'loopback')).toBe('127.0.0.1')
       })
       it('should accept pre-defined names in an array', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, ['loopback', '10.0.0.1'])).toBe('127.0.0.1')
       })
       it('should not alter input array', () => {
         const arr = ['loopback', '10.0.0.1']
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, arr)).toBe('127.0.0.1')
         expect(arr).toEqual(['loopback', '10.0.0.1'])
       })
       it('should reject non-IP', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         try {
           proxyaddr(req, 'blegh')
@@ -106,7 +106,7 @@ describe('proxyaddr(req, trust)', () => {
         }
       })
       it('should reject bad CIDR', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         try {
           proxyaddr(req, '10.0.0.1/internet')
@@ -139,7 +139,7 @@ describe('proxyaddr(req, trust)', () => {
         }
       })
       it('should reject bad netmask', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         try {
           proxyaddr(req, '10.0.0.1/255.0.255.0')
@@ -176,7 +176,7 @@ describe('proxyaddr(req, trust)', () => {
 
         const req = createReq('127.0.0.1', {
           'x-forwarded-for': '192.168.0.1, 10.0.0.1'
-        }) as IncomingMessage
+        })
 
         proxyaddr(req, (addr, i) => {
           log.push([addr, i])
@@ -193,21 +193,21 @@ describe('proxyaddr(req, trust)', () => {
 
   describe('with all trusted', () => {
     it('should return socket address with no headers', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
+      const req = createReq('127.0.0.1')
 
       expect(proxyaddr(req, all)).toBe('127.0.0.1')
     })
     it('should return header value', () => {
       const req = createReq('127.0.0.1', {
         'x-forwarded-for': '10.0.0.1'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, all)).toBe('10.0.0.1')
     })
     it('should return furthest header value', () => {
       const req = createReq('127.0.0.1', {
         'x-forwarded-for': '10.0.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, all)).toBe('10.0.0.1')
     })
@@ -215,14 +215,14 @@ describe('proxyaddr(req, trust)', () => {
 
   describe('with none trusted', () => {
     it('should return socket address with no headers', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
+      const req = createReq('127.0.0.1')
 
       expect(proxyaddr(req, none)).toBe('127.0.0.1')
     })
     it('should return socket address with headers', () => {
       const req = createReq('127.0.0.1', {
         'x-forwarded-for': '10.0.0.1'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, none)).toBe('127.0.0.1')
     })
@@ -230,35 +230,35 @@ describe('proxyaddr(req, trust)', () => {
 
   describe('with some trusted', () => {
     it('should return socket address with no headers', () => {
-      const req = createReq('127.0.0.1') as IncomingMessage
+      const req = createReq('127.0.0.1')
 
       expect(proxyaddr(req, trust10x)).toBe('127.0.0.1')
     })
     it('should return socket address when not trusted', () => {
       const req = createReq('127.0.0.1', {
         'x-forwarded-for': '10.0.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, trust10x)).toBe('127.0.0.1')
     })
     it('should return header when socket trusted', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, trust10x)).toBe('192.168.0.1')
     })
     it('should return first untrusted after trusted', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, trust10x)).toBe('192.168.0.1')
     })
     it('should not skip untrusted', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '10.0.0.3, 192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, trust10x)).toBe('192.168.0.1')
     })
@@ -268,35 +268,35 @@ describe('proxyaddr(req, trust)', () => {
     it('should accept literal IP addresses', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['10.0.0.1', '10.0.0.2'])).toBe('192.168.0.1')
     })
     it('should not trust non-IP addresses', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2, localhost'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['10.0.0.1', '10.0.0.2'])).toBe('localhost')
     })
     it('should return socket address if none match', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['127.0.0.1', '192.168.0.100'])).toBe('10.0.0.1')
     })
 
     describe('when array is empty', () => {
       it('should return socket address', () => {
-        const req = createReq('127.0.0.1') as IncomingMessage
+        const req = createReq('127.0.0.1')
 
         expect(proxyaddr(req, [])).toBe('127.0.0.1')
       })
       it('should return socket address with headers', () => {
         const req = createReq('127.0.0.1', {
           'x-forwarded-for': '10.0.0.1, 10.0.0.2'
-        }) as IncomingMessage
+        })
 
         expect(proxyaddr(req, [])).toBe('127.0.0.1')
       })
@@ -307,21 +307,21 @@ describe('proxyaddr(req, trust)', () => {
     it('should accept literal IP addresses', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['10.0.0.1', '10.0.0.2'])).toBe('192.168.0.1')
     })
     it('should accept CIDR notation', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.200'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, '10.0.0.2/26')).toBe('10.0.0.200')
     })
     it('should accept netmask notation', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.200'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, '10.0.0.2/255.255.255.192')).toBe('10.0.0.200')
     })
@@ -330,14 +330,14 @@ describe('proxyaddr(req, trust)', () => {
     it('should accept literal IP addresses', () => {
       const req = createReq('fe80::1', {
         'x-forwarded-for': '2002:c000:203::1, fe80::2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['fe80::1', 'fe80::2'])).toBe('2002:c000:203::1')
     })
     it('should accept CIDR notation', () => {
       const req = createReq('fe80::1', {
         'x-forwarded-for': '2002:c000:203::1, fe80::ff00'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, 'fe80::/125')).toBe('fe80::ff00')
     })
@@ -346,14 +346,14 @@ describe('proxyaddr(req, trust)', () => {
     it('should match respective versions', () => {
       const req = createReq('::1', {
         'x-forwarded-for': '2002:c000:203::1'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['127.0.0.1', '::1'])).toBe('2002:c000:203::1')
     })
     it('should not match IPv4 to IPv6', () => {
       const req = createReq('::1', {
         'x-forwarded-for': '2002:c000:203::1'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, '127.0.0.1')).toBe('::1')
     })
@@ -363,21 +363,21 @@ describe('proxyaddr(req, trust)', () => {
     it('should match IPv4 trust to IPv6 request', () => {
       const req = createReq('::ffff:a00:1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['10.0.0.1', '10.0.0.2'])).toBe('192.168.0.1')
     })
     it('should match IPv4 netmask trust to IPv6 request', () => {
       const req = createReq('::ffff:a00:1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['10.0.0.1/16'])).toBe('192.168.0.1')
     })
     it('should match IPv6 trust to IPv4 request', () => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       expect(proxyaddr(req, ['::ffff:a00:1', '::ffff:a00:2'])).toBe('192.168.0.1')
     })
@@ -410,7 +410,7 @@ describe('proxyaddr(req, trust)', () => {
     ])('with addresses 10.0.0.1, 10.0.0.2, 192.168.0.1', ({ trust, address }) => {
       const req = createReq('10.0.0.1', {
         'x-forwarded-for': '192.168.0.1, 10.0.0.2'
-      }) as IncomingMessage
+      })
 
       it(`should use the address that is at most ${trust} hops away`, () => {
         expect(proxyaddr(req, trust)).toBe(address)

--- a/tests/modules/proxy-addr.test.ts
+++ b/tests/modules/proxy-addr.test.ts
@@ -74,6 +74,13 @@ describe('proxyaddr(req, trust)', () => {
 
         expect(proxyaddr(req, ['loopback', '10.0.0.1'])).toBe('127.0.0.1')
       })
+      it('should not alter input array', () => {
+        const arr = ['loopback', '10.0.0.1']
+        const req = createReq('127.0.0.1') as IncomingMessage
+
+        expect(proxyaddr(req, arr)).toBe('127.0.0.1')
+        expect(arr).toEqual(['loopback', '10.0.0.1'])
+      })
       it('should reject non-IP', () => {
         const req = createReq('127.0.0.1') as IncomingMessage
 


### PR DESCRIPTION
- Adds 'trust proxy' setting from Express, defaulting to `0` (do not trust proxies).
- Fixes issue causing the socket connection IP address to always be considered 'trusted' (breaking change).

Namely, [here](https://github.com/tinyhttp/tinyhttp/blob/d001072ca58779fc50b837a60b31e7ce1b81fa15/packages/app/src/request.ts#L26), the returned value from `compile` and therefore `trustRemoteAddress` is a `function`, which is always truthy. Therefore `req.proto` is always derived from `X-Forwarded-Proto`.

Additionally, on every request `trustRemoteAddress` compiles a trust function which **will always trust the remote address**, which could be considered a security vulnerability.