### PR TITLE
feat(res): remove dependency on escapeHTML and inline it

### DIFF
--- a/packages/res/src/redirect.ts
+++ b/packages/res/src/redirect.ts
@@ -1,7 +1,7 @@
 import { type IncomingMessage as Req, type ServerResponse as Res, STATUS_CODES } from 'node:http'
-import { escapeHTML } from 'es-escape-html'
 import { formatResponse } from './format.js'
 import { setLocationHeader } from './headers.js'
+import { escapeHTML } from './util.js'
 
 type next = (err?: any) => void
 

--- a/packages/res/src/util.ts
+++ b/packages/res/src/util.ts
@@ -32,3 +32,48 @@ export function normalizeTypes(types: string[]): NormalizedType[] {
 
   return ret
 }
+
+const matchHtmlRegExp = /["'&<>]/
+
+export function escapeHTML(str: string): string {
+  const match = matchHtmlRegExp.exec(str)
+
+  if (!match) {
+    // stringify in case input is not a string
+    return String(str)
+  }
+
+  let escapeChar: string
+  let html = ''
+  let index = 0
+  let lastIndex = 0
+
+  for (index = match.index; index < str.length; index++) {
+    switch (str.charCodeAt(index)) {
+      case 34: // "
+        escapeChar = '&quot;'
+        break
+      case 38: // &
+        escapeChar = '&amp;'
+        break
+      case 39: // '
+        escapeChar = '&#39;'
+        break
+      case 60: // <
+        escapeChar = '&lt;'
+        break
+      case 62: // >
+        escapeChar = '&gt;'
+        break
+      default:
+        continue
+    }
+
+    if (lastIndex !== index) html += str.substring(lastIndex, index)
+
+    lastIndex = index + 1
+    html += escapeChar
+  }
+
+  return lastIndex !== index ? html + str.substring(lastIndex, index) : html
+}

--- a/tests/modules/etag.test.ts
+++ b/tests/modules/etag.test.ts
@@ -5,7 +5,7 @@ import { eTag } from '../../packages/etag/src'
 describe('etag(entity)', () => {
   it('should require an entity', () => {
     try {
-      eTag(undefined)
+      eTag(undefined!)
     } catch (e) {
       expect((e as TypeError).message).toBe('argument entity is required')
     }

--- a/tests/modules/res.test.ts
+++ b/tests/modules/res.test.ts
@@ -18,6 +18,7 @@ import {
   setLocationHeader,
   setVaryHeader
 } from '../../packages/res/src/index.js'
+import { escapeHTML } from '../../packages/res/src/util.js'
 import { runServer } from '../../test_helpers/runServer'
 
 const __dirname = dirname(import.meta)
@@ -487,6 +488,189 @@ describe('Response extensions', () => {
 
         await makeFetch(app)('/').expect('Location', '/').expectStatus(200)
       })
+    })
+  })
+})
+
+/**
+ * Taken from https://github.com/component/escape-html/blob/master/test/index.js
+ */
+describe('util > escapeHTML', () => {
+  it('when string is undefined should return "undefined"', () => {
+    expect(escapeHTML(undefined!)).toBe('undefined')
+  })
+
+  it('when string is null should return "null"', () => {
+    expect(escapeHTML(null!)).toBe('null')
+  })
+
+  it('when string is a number should return stringified number', () => {
+    expect(escapeHTML(42 as unknown as string)).toBe('42')
+  })
+
+  it('when string is an object should return "[object Object]"', () => {
+    expect(escapeHTML({} as string)).toBe('[object Object]')
+  })
+
+  describe("when string contains '\"'", () => {
+    it('as only character it should replace with "&quot;"', () => {
+      expect(escapeHTML('"')).toBe('&quot;')
+    })
+
+    it('as first character it should replace with "&quot;"', () => {
+      expect(escapeHTML('"bar')).toBe('&quot;bar')
+    })
+
+    describe('as last character', () => {
+      it('should replace with "&quot;"', () => {
+        expect(escapeHTML('foo"')).toBe('foo&quot;')
+      })
+    })
+
+    describe('as middle character', () => {
+      it('should replace with "&quot;"', () => {
+        expect(escapeHTML('foo"bar')).toBe('foo&quot;bar')
+      })
+    })
+
+    describe('multiple times', () => {
+      it('should replace all occurrances with "&quot;"', () => {
+        expect(escapeHTML('foo""bar')).toBe('foo&quot;&quot;bar')
+      })
+    })
+  })
+
+  describe('when string contains "&"', () => {
+    describe('as only character', () => {
+      it('should replace with "&amp;"', () => {
+        expect(escapeHTML('&')).toBe('&amp;')
+      })
+    })
+
+    describe('as first character', () => {
+      it('should replace with "&amp;"', () => {
+        expect(escapeHTML('&bar')).toBe('&amp;bar')
+      })
+    })
+
+    describe('as last character', () => {
+      it('should replace with "&amp;"', () => {
+        expect(escapeHTML('foo&')).toBe('foo&amp;')
+      })
+    })
+
+    describe('as middle character', () => {
+      it('should replace with "&amp;"', () => {
+        expect(escapeHTML('foo&bar')).toBe('foo&amp;bar')
+      })
+    })
+
+    describe('multiple times', () => {
+      it('should replace all occurrances with "&amp;"', () => {
+        expect(escapeHTML('foo&&bar')).toBe('foo&amp;&amp;bar')
+      })
+    })
+  })
+
+  describe('when string contains "\'"', () => {
+    describe('as only character', () => {
+      it('should replace with "&#39;"', () => {
+        expect(escapeHTML("'")).toBe('&#39;')
+      })
+    })
+
+    describe('as first character', () => {
+      it('should replace with "&#39;"', () => {
+        expect(escapeHTML("'bar")).toBe('&#39;bar')
+      })
+    })
+
+    describe('as last character', () => {
+      it('should replace with "&#39;"', () => {
+        expect(escapeHTML("foo'")).toBe('foo&#39;')
+      })
+    })
+
+    describe('as middle character', () => {
+      it('should replace with "&#39;"', () => {
+        expect(escapeHTML("foo'bar")).toBe('foo&#39;bar')
+      })
+    })
+
+    describe('multiple times', () => {
+      it('should replace all occurrances with "&#39;"', () => {
+        expect(escapeHTML("foo''bar")).toBe('foo&#39;&#39;bar')
+      })
+    })
+  })
+
+  describe('when string contains "<"', () => {
+    describe('as only character', () => {
+      it('should replace with "&lt;"', () => {
+        expect(escapeHTML('<')).toBe('&lt;')
+      })
+    })
+
+    describe('as first character', () => {
+      it('should replace with "&lt;"', () => {
+        expect(escapeHTML('<bar')).toBe('&lt;bar')
+      })
+    })
+
+    describe('as last character', () => {
+      it('should replace with "&lt;"', () => {
+        expect(escapeHTML('foo<')).toBe('foo&lt;')
+      })
+    })
+
+    describe('as middle character', () => {
+      it('should replace with "&lt;"', () => {
+        expect(escapeHTML('foo<bar')).toBe('foo&lt;bar')
+      })
+    })
+
+    describe('multiple times', () => {
+      it('should replace all occurrances with "&lt;"', () => {
+        expect(escapeHTML('foo<<bar')).toBe('foo&lt;&lt;bar')
+      })
+    })
+  })
+
+  describe('when string contains ">"', () => {
+    describe('as only character', () => {
+      it('should replace with "&gt;"', () => {
+        expect(escapeHTML('>')).toBe('&gt;')
+      })
+    })
+
+    describe('as first character', () => {
+      it('should replace with "&gt;"', () => {
+        expect(escapeHTML('>bar')).toBe('&gt;bar')
+      })
+    })
+
+    describe('as last character', () => {
+      it('should replace with "&gt;"', () => {
+        expect(escapeHTML('foo>')).toBe('foo&gt;')
+      })
+    })
+
+    describe('as middle character', () => {
+      it('should replace with "&gt;"', () => {
+        expect(escapeHTML('foo>bar')).toBe('foo&gt;bar')
+      })
+    })
+
+    describe('multiple times', () => {
+      it('should replace all occurrances with "&gt;"', () => {
+        expect(escapeHTML('foo>>bar')).toBe('foo&gt;&gt;bar')
+      })
+    })
+  })
+
+  describe('when escaped character mixed', () => {
+    it('should escape all occurrances', () => {
+      expect(escapeHTML('&foo <> bar "fizz" l\'a')).toBe('&amp;foo &lt;&gt; bar &quot;fizz&quot; l&#39;a')
     })
   })
 })


### PR DESCRIPTION
Passes all the tests unlike es-escape-html and is one less dependency on `@tinyhttp/res`